### PR TITLE
src: allow custom headers

### DIFF
--- a/src/transport/http/binary_emitter.ts
+++ b/src/transport/http/binary_emitter.ts
@@ -18,7 +18,7 @@ async function emit(event: CloudEvent, options: Options, headers: Headers): Prom
   const config = {
     ...options,
     method: "POST",
-    headers: { ...contentType, ...headers },
+    headers: { ...contentType, ...headers, ...options.headers as Headers},
     data: asData(event.data, event.datacontenttype as string)
   };
   return axios.request(config as AxiosRequestConfig);

--- a/test-ts/http_emitter_test.ts
+++ b/test-ts/http_emitter_test.ts
@@ -68,6 +68,17 @@ describe("HTTP Transport Binding Emitter for CloudEvents", () => {
       expect(headers[v1Headers.BINARY_HEADERS.TIME]).to.equal(event.time);
     });
 
+    it("Sends a binary CloudEvent with Custom Headers", () => {
+      emitter.send(event, { headers: { customheader: "value" } }).then((response: { data: { [k: string]: string } }) => {
+        // A binary message will have a ce-id header
+        expect(response.data.customheader).to.equal("value");
+        expect(response.data[v1Headers.BINARY_HEADERS.ID]).to.equal(event.id);
+        expect(response.data[v1Headers.BINARY_HEADERS.SPEC_VERSION]).to.equal(Version.V1);
+        // A binary message will have a request body for the data
+        expect(response.data.lunchBreak).to.equal(data.lunchBreak);
+      }).catch(expect.fail);
+    });
+
     it("Sends a structured 1.0 CloudEvent if specified", () => {
       emitter.send(event, { protocol: Protocol.HTTPStructured })
         .then((response: { data: { [k: string]: string | {}, data: { lunchBreak: string } } }) => {


### PR DESCRIPTION
This adds a test and also the ability to send a customer header to the Emitter.send method


I had to add this, https://github.com/lance/sdk-javascript/compare/refactor-api...lholmquist:custom-headers?expand=1#diff-cd195927075bff5495d70edbbf239548R21, because the "options.headers"
were getting overwritten by during the merge


Signed-off-by: Lucas Holmquist <lholmqui@redhat.com>